### PR TITLE
Make tag regex work for all languages

### DIFF
--- a/src/vue-app/extensions/Category.js
+++ b/src/vue-app/extensions/Category.js
@@ -47,7 +47,7 @@ export default class Category extends Node {
 
 	inputRules({ type }) {
 		return [
-			inlineInputRule(/#([\w-/\u05D0-\u05EA\u0620-\u063F\u0641-\u064A\u0675-\u06D3\u0710-\u071C\u071E-\u072F\u074E-\u077F\u08A0-\u08AC\u08AE-\u08B4\u07C1-\u07C9\u07CC-\u07E9]+)([\s\t.,])/, type, match => {
+			inlineInputRule(/#([^\s\t!@#$%^&*()=+./\\,[\]{};:'"?]+)([\s\t.,])/, type, match => {
 				let [, text, endingCharacter] = match;
 
 				return { text, endingCharacter };


### PR DESCRIPTION
Instead of listing the characters that can be a part of a tag,
we list what can't be a part of a tag.

Fixing https://github.com/pretzelhands/notebag/issues/4.