### PR TITLE
Fix "No content" in the preview

### DIFF
--- a/src/vue-app/components/NoteList.vue
+++ b/src/vue-app/components/NoteList.vue
@@ -144,8 +144,7 @@
 			},
 
 			notePreview(note) {
-				const sanitizedNotePreview = note.preview.replace(/<span class="category-pill".*>.*<\/span>/gi, "");
-
+				const sanitizedNotePreview = note.preview.replace(/<span class="category-pill".*?>.*?<\/span>/gi, "");
 				return stripTags(sanitizedNotePreview).trim().length > 0
 					? stripTags(sanitizedNotePreview, ALLOWED_HTML_TAGS, " ").trim()
 					: "No content";


### PR DESCRIPTION
Fixed removing category tags when previewing.

The current regexp is too greedy and eats the whole content
if there a tag at the end of the note.